### PR TITLE
Update security.yml

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -8,11 +8,9 @@ on:
 
 permissions:
   contents: read
-  security-events: write
   actions: read
 
 jobs:
-
   secret-scan:
     name: Secret Scan (Gitleaks)
     runs-on: ubuntu-latest
@@ -20,27 +18,10 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Run Gitleaks
         uses: gitleaks/gitleaks-action@v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-  codeql-analysis:
-    name: CodeQL Analysis
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
-        with:
-          languages: javascript
-
-      - name: Autobuild
-        uses: github/codeql-action/autobuild@v3
-
-      - name: Run CodeQL analysis
-        uses: github/codeql-action/analyze@v3


### PR DESCRIPTION
## What changed
- Removed the custom CodeQL job from `security.yml`
- Kept the Gitleaks secret scan in the Security Pipeline
- Added full Git history checkout with `fetch-depth: 0` for Gitleaks

## Why
CodeQL is now enabled through GitHub's default CodeQL setup.  
The custom CodeQL job caused a conflict because CodeQL was configured twice.

Gitleaks needs full Git history to scan correctly, so `fetch-depth: 0` was added.

## Result
- CodeQL runs through GitHub Code Scanning default setup
- Our custom Security Pipeline focuses on secret scanning with Gitleaks
- The workflow is cleaner and avoids duplicate CodeQL configuration